### PR TITLE
Fixed error `/bin/sh: 1: export: ./bin/benchmarker: bad variable name` when running `make run`

### DIFF
--- a/benchmarker/Makefile
+++ b/benchmarker/Makefile
@@ -11,7 +11,7 @@ dev: build
 
 .PHONY: run
 run: build
-	export ./bin/benchmarker --stage=prod --request-timeout=10s 
+	./bin/benchmarker --stage=prod --request-timeout=10s
 
 bin/benchmarker: $(shell find . -name '*.go' -print)
 	go build -buildvcs=false -o $@ .


### PR DESCRIPTION
Fixed the following error when executing benchmarker

```
isucon@ip-172-31-47-11:~/isucon12-final/benchmarker$ make run
export ./bin/benchmarker --stage=prod --request-timeout=10s
/bin/sh: 1: export: ./bin/benchmarker: bad variable name
make: *** [Makefile:14: run] Error 2
```
